### PR TITLE
fix: add conditional statement into __exit__ method

### DIFF
--- a/service_layer/uow.py
+++ b/service_layer/uow.py
@@ -22,7 +22,8 @@ class UnitOfWorkBase(ABC):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.rollback()
+        if exc_type:
+            self.rollback()
 
     @abstractmethod
     def commit(self):


### PR DESCRIPTION
Hello, manukanne.

Found your blog posts and code repository very helpful for implementing DDD with fastapi, sqlmodel. I've been using the **uow** related code as-is, but I noticed that the rollback keeps getting executed. Upon investigation, I found some suggested code improvements, so I'll be sending a PR.

Modified the code `rollback` is only executed in the method `__exit__` when an exception occurs.

Thanks again. Have a great day.